### PR TITLE
Revert order of `EmbeddedDataSpecification` attributes in the schemas

### DIFF
--- a/schemas/json/aas.json
+++ b/schemas/json/aas.json
@@ -503,16 +503,16 @@
     "EmbeddedDataSpecification": {
       "type": "object",
       "properties": {
-        "dataSpecificationContent": {
-          "$ref": "#/definitions/DataSpecificationContent_choice"
-        },
         "dataSpecification": {
           "$ref": "#/definitions/Reference"
+        },
+        "dataSpecificationContent": {
+          "$ref": "#/definitions/DataSpecificationContent_choice"
         }
       },
       "required": [
-        "dataSpecificationContent",
-        "dataSpecification"
+        "dataSpecification",
+        "dataSpecificationContent"
       ]
     },
     "Entity": {

--- a/schemas/rdf/examples/generated/AdministrativeInformation/maximal.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/maximal.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1230"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/four_digits.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/four_digits.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1230"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/fuzzed_01.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1230"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/fuzzed_02.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1230"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/fuzzed_03.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1230"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/fuzzed_04.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1230"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/one.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/one.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1230"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/three_digits.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/three_digits.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1230"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/two_digits.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/two_digits.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1230"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/zero.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/revisionOverPatternExamples/zero.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1230"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/four_digits.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/four_digits.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1230"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/fuzzed_01.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "59"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/fuzzed_02.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "116"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/fuzzed_03.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "7"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/fuzzed_04.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "32"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/one.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/one.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "1"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/three_digits.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/three_digits.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "120"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/two_digits.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/two_digits.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "10"^^xs:string ;

--- a/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/zero.ttl
+++ b/schemas/rdf/examples/generated/AdministrativeInformation/versionOverPatternExamples/zero.ttl
@@ -9,6 +9,15 @@
         rdf:type aas:AdministrativeInformation ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -22,15 +31,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 0843a1d1"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_bebf64f0"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:something14:18179b7a"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/AdministrativeInformation/version> "0"^^xs:string ;

--- a/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/AnnotatedRelationshipElement/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/AnnotatedRelationshipElement/maximal.ttl
+++ b/schemas/rdf/examples/generated/AnnotatedRelationshipElement/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_01.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom> [

--- a/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_02.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom> [

--- a/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_03.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom> [

--- a/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_04.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom> [

--- a/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_05.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom> [

--- a/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_06.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom> [

--- a/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_07.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom> [

--- a/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_08.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom> [

--- a/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_09.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom> [

--- a/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/AssetAdministrationShell/idShortOverPatternExamples/fuzzed_10.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom> [

--- a/schemas/rdf/examples/generated/AssetAdministrationShell/maximal.ttl
+++ b/schemas/rdf/examples/generated/AssetAdministrationShell/maximal.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/derivedFrom> [

--- a/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/minus_zero_offset.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/minus_zero_offset.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/plus_zero_offset.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/plus_zero_offset.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/random_positive.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/random_positive.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/very_large_year.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/very_large_year.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/year_1_bce_is_a_leap_year.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/year_1_bce_is_a_leap_year.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/year_5_bce_is_a_leap_year.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/lastUpdateOverPatternExamples/year_5_bce_is_a_leap_year.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/day_seconds.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/day_seconds.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/full.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/full.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/long_second_fractal.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/long_second_fractal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/many_many_seconds.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/many_many_seconds.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/month_seconds.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/month_seconds.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/only_seconds.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/only_seconds.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/only_year.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maxIntervalOverPatternExamples/only_year.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/maximal.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/day_seconds.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/day_seconds.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/full.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/full.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/long_second_fractal.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/long_second_fractal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/many_many_seconds.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/many_many_seconds.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/month_seconds.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/month_seconds.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/only_seconds.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/only_seconds.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/only_year.ttl
+++ b/schemas/rdf/examples/generated/BasicEventElement/minIntervalOverPatternExamples/only_year.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/BasicEventElement/observed> [

--- a/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/dash.ttl
+++ b/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/dash.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/dots.ttl
+++ b/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/dots.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/number prefix and suffix.ttl
+++ b/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/number prefix and suffix.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/only_letters.ttl
+++ b/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/only_letters.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/plus.ttl
+++ b/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/plus.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/random_common_MIME_type.ttl
+++ b/schemas/rdf/examples/generated/Blob/contentTypeOverPatternExamples/random_common_MIME_type.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/Blob/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Blob/maximal.ttl
+++ b/schemas/rdf/examples/generated/Blob/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Blob/value> "FYFZv/O3Z+zHt1M="^^xs:base64Binary ;

--- a/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/Capability/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/Capability/maximal.ttl
+++ b/schemas/rdf/examples/generated/Capability/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_01.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_8ccad77f"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 19945c14"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_a864dcb4"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/ConceptDescription/isCaseOf> [

--- a/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_02.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_8ccad77f"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 19945c14"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_a864dcb4"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/ConceptDescription/isCaseOf> [

--- a/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_03.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_8ccad77f"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 19945c14"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_a864dcb4"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/ConceptDescription/isCaseOf> [

--- a/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_04.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_8ccad77f"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 19945c14"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_a864dcb4"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/ConceptDescription/isCaseOf> [

--- a/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_05.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_8ccad77f"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 19945c14"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_a864dcb4"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/ConceptDescription/isCaseOf> [

--- a/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_06.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_8ccad77f"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 19945c14"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_a864dcb4"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/ConceptDescription/isCaseOf> [

--- a/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_07.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_8ccad77f"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 19945c14"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_a864dcb4"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/ConceptDescription/isCaseOf> [

--- a/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_08.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_8ccad77f"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 19945c14"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_a864dcb4"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/ConceptDescription/isCaseOf> [

--- a/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_09.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_8ccad77f"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 19945c14"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_a864dcb4"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/ConceptDescription/isCaseOf> [

--- a/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/ConceptDescription/idShortOverPatternExamples/fuzzed_10.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_8ccad77f"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 19945c14"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_a864dcb4"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/ConceptDescription/isCaseOf> [

--- a/schemas/rdf/examples/generated/ConceptDescription/maximal.ttl
+++ b/schemas/rdf/examples/generated/ConceptDescription/maximal.ttl
@@ -27,6 +27,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_8ccad77f"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -40,15 +49,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 19945c14"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_a864dcb4"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:example14:c4971d26"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/ConceptDescription/isCaseOf> [

--- a/schemas/rdf/examples/generated/DataSpecificationIec61360/maximal.ttl
+++ b/schemas/rdf/examples/generated/DataSpecificationIec61360/maximal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -51,15 +60,6 @@
                 <https://admin-shell.io/aas/3/1/LevelType/nom> "true"^^xs:boolean ;
                 <https://admin-shell.io/aas/3/1/LevelType/typ> "true"^^xs:boolean ;
                 <https://admin-shell.io/aas/3/1/LevelType/max> "true"^^xs:boolean ;
-            ] ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/DataSpecificationIec61360/minimal.ttl
+++ b/schemas/rdf/examples/generated/DataSpecificationIec61360/minimal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/EmbeddedDataSpecification/maximal.ttl
+++ b/schemas/rdf/examples/generated/EmbeddedDataSpecification/maximal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/EmbeddedDataSpecification/minimal.ttl
+++ b/schemas/rdf/examples/generated/EmbeddedDataSpecification/minimal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Entity/statements> [

--- a/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Entity/statements> [

--- a/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Entity/statements> [

--- a/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Entity/statements> [

--- a/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Entity/statements> [

--- a/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Entity/statements> [

--- a/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Entity/statements> [

--- a/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Entity/statements> [

--- a/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Entity/statements> [

--- a/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/Entity/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Entity/statements> [

--- a/schemas/rdf/examples/generated/Entity/maximal.ttl
+++ b/schemas/rdf/examples/generated/Entity/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Entity/statements> [

--- a/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/dash.ttl
+++ b/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/dash.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/dots.ttl
+++ b/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/dots.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/number prefix and suffix.ttl
+++ b/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/number prefix and suffix.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/only_letters.ttl
+++ b/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/only_letters.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/plus.ttl
+++ b/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/plus.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/random_common_MIME_type.ttl
+++ b/schemas/rdf/examples/generated/File/contentTypeOverPatternExamples/random_common_MIME_type.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/File/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/maximal.ttl
+++ b/schemas/rdf/examples/generated/File/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "#%4b%6AT"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "RqjJsrvAJ1Uk:%9d'%8C_%81k,%Fcd?yw,@B,M=.EE%8E"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "#/%38%21&"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "//QQ%BF(,xe;A.@%94($,=%38@"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "/;=:&%30%1a;77@%321%A4%21;%FC:=/;=,=%13y:%2D;+J%c6%bcU%D3;j1G:sg=%EcA%f3/@z%29%B7&B;=#@H%8D=U%FE%5e%22%Db?,+"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "#;"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "#%6A%6AT"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "//bVfwa.f./%DC%60O@=;;%63;6%9b;l%E8Ib@$e::9%c0;w%0F;P%bD!v,$;@$;,=$%454-:R%2C%5E%4b2B=%eB%Da%0E%C4p%5c&;%de@%82%fB;v%bbw5q=%57%EE%1c;%e0%2A%af%1c0%eDm%5c%D2&;k*%12%5B;%A0&,:&$;:&%33;+,;%6c5;l%1D%35+%4a&%Fe+lk,+;C,~W=+=%3bn;;-p%3f%66R+%53;o%Bd$BIW%0d%Be%0E+l=I(k%Ac:,R%e6%9E%21%7f%54;;N%F3X@%8f%03%AE(=%9b:/;%F20;0L%27%4F;;%b0:9;%D5%31%1C;21u@%CE%fAE@$=#T%7D"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "q2t2uv://777646689268.160810318.01435447069935.47:/%Be/%04@%Cd@P%dc:C$&~x=;%3f9+;;sr-i=p,///;%D5@@x&;V@I%16/+;%e4,@%AA@Ih:%8Dg=%F8P,v%dE%3E%03%62%FB=$R,&%ac%71;u%11l8*;,;$%Faj:;;;%ee$%8b%EC@%4Alo;t,%0b%eB%D5%EA:%De;$$1:@/%8e%0D&9%C8M;@5%28%4E%BC@%34;;@%EC=tL)x(/M%D3%aF&%Ec;=%aa$$j;;%B3@hk=e:%DB%24Z;%F6%9E+%8e;=;%ba;;%b3;;p%f11=%34%c0;#lR:+k%BE4%EB"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "#%59T=%e1&&%b4%53EYU?,/q%87%c6He"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/made_up_01.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/made_up_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "http://www.example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/made_up_02.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/made_up_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "ftp://ftp.is.co.za/rfc/rfc1808.txt"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/made_up_03.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/made_up_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "mailto:John.Doe@example.org"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/made_up_04.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/made_up_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "news:comp.infosystems.www.servers.unix"^^xs:string ;

--- a/schemas/rdf/examples/generated/File/valueOverPatternExamples/made_up_05.ttl
+++ b/schemas/rdf/examples/generated/File/valueOverPatternExamples/made_up_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/File/value> "telnet://192.0.2.16:80/"^^xs:string ;

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.ttl
@@ -1,0 +1,45 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "i-enochian"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_84b0b440"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/definition> [
+                rdf:type aas:LangStringDefinitionTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "zh-cmn-Hans-CN"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.ttl
@@ -1,0 +1,45 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "i-enochian"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_84b0b440"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/definition> [
+                rdf:type aas:LangStringDefinitionTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "yue-HK"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_variant_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_variant_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_variant_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_variant_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_variant.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_variant.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_subtags_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_subtags_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_subtags_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_subtags_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.ttl
@@ -1,0 +1,45 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "i-enochian"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_84b0b440"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/definition> [
+                rdf:type aas:LangStringDefinitionTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "de"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.ttl
@@ -1,0 +1,45 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "i-enochian"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_84b0b440"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/definition> [
+                rdf:type aas:LangStringDefinitionTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "fr"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/maximal.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/maximal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/minimal.ttl
+++ b/schemas/rdf/examples/generated/LangStringDefinitionTypeIec61360/minimal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_29357dd5"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringNameType/languageOverPatternExamples/extended_language_subtags_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringNameType/languageOverPatternExamples/extended_language_subtags_1.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Referable/displayName> [
+        rdf:type aas:LangStringNameType ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/language> "zh-cmn-Hans-CN"^^xs:string ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_09c304fd"^^xs:string ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringNameType/languageOverPatternExamples/extended_language_subtags_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringNameType/languageOverPatternExamples/extended_language_subtags_3.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Referable/displayName> [
+        rdf:type aas:LangStringNameType ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/language> "zh-yue-HK"^^xs:string ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_09c304fd"^^xs:string ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringNameType/languageOverPatternExamples/language_region_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringNameType/languageOverPatternExamples/language_region_1.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Referable/displayName> [
+        rdf:type aas:LangStringNameType ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/language> "de-DE"^^xs:string ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_09c304fd"^^xs:string ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringNameType/languageOverPatternExamples/simple_language_subtag_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringNameType/languageOverPatternExamples/simple_language_subtag_1.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Referable/displayName> [
+        rdf:type aas:LangStringNameType ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/language> "de"^^xs:string ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_09c304fd"^^xs:string ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.ttl
@@ -1,0 +1,40 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "zh-cmn-Hans-CN"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_c98d9907"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.ttl
@@ -1,0 +1,40 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "zh-yue-HK"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_c98d9907"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_1.ttl
@@ -1,0 +1,40 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "de-DE"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_c98d9907"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_variant_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_variant_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_variant_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_variant_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_variant.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_variant.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_subtags_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_subtags_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_subtags_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_subtags_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.ttl
@@ -1,0 +1,40 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "de"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_c98d9907"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/maximal.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/maximal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/minimal.ttl
+++ b/schemas/rdf/examples/generated/LangStringPreferredNameTypeIec61360/minimal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -21,15 +30,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.ttl
@@ -1,0 +1,45 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "i-enochian"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_84b0b440"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/shortName> [
+                rdf:type aas:LangStringShortNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "zh-cmn-Hans-CN"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.ttl
@@ -1,0 +1,45 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "i-enochian"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_84b0b440"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/shortName> [
+                rdf:type aas:LangStringShortNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "yue-HK"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_region_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_region_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_region_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_region_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_region_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_region_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_region_variant_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_region_variant_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_region_variant_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_region_variant_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_variant.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_variant.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_subtags_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_subtags_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_subtags_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/private_use_subtags_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.ttl
@@ -1,0 +1,45 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "i-enochian"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_84b0b440"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/shortName> [
+                rdf:type aas:LangStringShortNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "de"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.ttl
@@ -1,0 +1,45 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
+        rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
+            rdf:type aas:DataSpecificationIec61360 ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "i-enochian"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_84b0b440"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
+                rdf:type aas:LangStringPreferredNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "en-GB"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English 5b15c20d"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/shortName> [
+                rdf:type aas:LangStringShortNameTypeIec61360 ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/language> "fr"^^xs:string ;
+                <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
+            ] ;
+            <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
+        ] ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_1.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_2.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_2.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_3.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/maximal.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/maximal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/minimal.ttl
+++ b/schemas/rdf/examples/generated/LangStringShortNameTypeIec61360/minimal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_75139f2c"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_13759f45"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [

--- a/schemas/rdf/examples/generated/LangStringTextType/languageOverPatternExamples/extended_language_subtags_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringTextType/languageOverPatternExamples/extended_language_subtags_1.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Referable/description> [
+        rdf:type aas:LangStringTextType ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/language> "zh-cmn-Hans-CN"^^xs:string ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_5340dd75"^^xs:string ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringTextType/languageOverPatternExamples/extended_language_subtags_3.ttl
+++ b/schemas/rdf/examples/generated/LangStringTextType/languageOverPatternExamples/extended_language_subtags_3.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Referable/description> [
+        rdf:type aas:LangStringTextType ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/language> "zh-yue-HK"^^xs:string ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_5340dd75"^^xs:string ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringTextType/languageOverPatternExamples/language_region_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringTextType/languageOverPatternExamples/language_region_1.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Referable/description> [
+        rdf:type aas:LangStringTextType ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/language> "de-DE"^^xs:string ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_5340dd75"^^xs:string ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LangStringTextType/languageOverPatternExamples/simple_language_subtag_1.ttl
+++ b/schemas/rdf/examples/generated/LangStringTextType/languageOverPatternExamples/simple_language_subtag_1.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+<something_142922d6> rdf:type aas:AssetAdministrationShell ;
+    <https://admin-shell.io/aas/3/1/Referable/description> [
+        rdf:type aas:LangStringTextType ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/language> "de"^^xs:string ;
+        <https://admin-shell.io/aas/3/1/AbstractLangString/text> "something_5340dd75"^^xs:string ;
+    ] ;
+    <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
+    <https://admin-shell.io/aas/3/1/AssetAdministrationShell/assetInformation> [
+        rdf:type aas:AssetInformation ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/assetKind> <https://admin-shell.io/aas/3/1/AssetKind/Role> ;
+        <https://admin-shell.io/aas/3/1/AssetInformation/globalAssetId> "something_eea66fa1"^^xs:string ;
+    ] ;
+.

--- a/schemas/rdf/examples/generated/LevelType/maximal.ttl
+++ b/schemas/rdf/examples/generated/LevelType/maximal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -27,15 +36,6 @@
                 <https://admin-shell.io/aas/3/1/LevelType/nom> "true"^^xs:boolean ;
                 <https://admin-shell.io/aas/3/1/LevelType/typ> "true"^^xs:boolean ;
                 <https://admin-shell.io/aas/3/1/LevelType/max> "true"^^xs:boolean ;
-            ] ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/LevelType/minimal.ttl
+++ b/schemas/rdf/examples/generated/LevelType/minimal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -27,15 +36,6 @@
                 <https://admin-shell.io/aas/3/1/LevelType/nom> "true"^^xs:boolean ;
                 <https://admin-shell.io/aas/3/1/LevelType/typ> "true"^^xs:boolean ;
                 <https://admin-shell.io/aas/3/1/LevelType/max> "true"^^xs:boolean ;
-            ] ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/MultiLanguageProperty/value> [

--- a/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/MultiLanguageProperty/value> [

--- a/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/MultiLanguageProperty/value> [

--- a/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/MultiLanguageProperty/value> [

--- a/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/MultiLanguageProperty/value> [

--- a/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/MultiLanguageProperty/value> [

--- a/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/MultiLanguageProperty/value> [

--- a/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/MultiLanguageProperty/value> [

--- a/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/MultiLanguageProperty/value> [

--- a/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/MultiLanguageProperty/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/MultiLanguageProperty/value> [

--- a/schemas/rdf/examples/generated/MultiLanguageProperty/maximal.ttl
+++ b/schemas/rdf/examples/generated/MultiLanguageProperty/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/MultiLanguageProperty/value> [

--- a/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Operation/inputVariables> [

--- a/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Operation/inputVariables> [

--- a/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Operation/inputVariables> [

--- a/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Operation/inputVariables> [

--- a/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Operation/inputVariables> [

--- a/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Operation/inputVariables> [

--- a/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Operation/inputVariables> [

--- a/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Operation/inputVariables> [

--- a/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Operation/inputVariables> [

--- a/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/Operation/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Operation/inputVariables> [

--- a/schemas/rdf/examples/generated/Operation/maximal.ttl
+++ b/schemas/rdf/examples/generated/Operation/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Operation/inputVariables> [

--- a/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Property/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Property/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Property/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Property/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Property/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Property/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Property/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Property/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Property/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/Property/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Property/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Property/maximal.ttl
+++ b/schemas/rdf/examples/generated/Property/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Property/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Range/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Range/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Range/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Range/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Range/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Range/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Range/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Range/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Range/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/Range/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Range/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/Range/maximal.ttl
+++ b/schemas/rdf/examples/generated/Range/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/Range/valueType> <https://admin-shell.io/aas/3/1/DataTypeDefXsd/Decimal> ;

--- a/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/ReferenceElement/value> [

--- a/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/ReferenceElement/value> [

--- a/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/ReferenceElement/value> [

--- a/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/ReferenceElement/value> [

--- a/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/ReferenceElement/value> [

--- a/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/ReferenceElement/value> [

--- a/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/ReferenceElement/value> [

--- a/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/ReferenceElement/value> [

--- a/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/ReferenceElement/value> [

--- a/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/ReferenceElement/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/ReferenceElement/value> [

--- a/schemas/rdf/examples/generated/ReferenceElement/maximal.ttl
+++ b/schemas/rdf/examples/generated/ReferenceElement/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/ReferenceElement/value> [

--- a/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/RelationshipElement/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/RelationshipElement/maximal.ttl
+++ b/schemas/rdf/examples/generated/RelationshipElement/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/RelationshipElement/first> [

--- a/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_01.ttl
@@ -51,6 +51,15 @@
     ] ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -64,15 +73,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English fbebdf98"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_db2f0b6e"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/Submodel/submodelElements> [

--- a/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_02.ttl
@@ -51,6 +51,15 @@
     ] ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -64,15 +73,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English fbebdf98"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_db2f0b6e"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/Submodel/submodelElements> [

--- a/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_03.ttl
@@ -51,6 +51,15 @@
     ] ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -64,15 +73,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English fbebdf98"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_db2f0b6e"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/Submodel/submodelElements> [

--- a/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_04.ttl
@@ -51,6 +51,15 @@
     ] ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -64,15 +73,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English fbebdf98"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_db2f0b6e"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/Submodel/submodelElements> [

--- a/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_05.ttl
@@ -51,6 +51,15 @@
     ] ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -64,15 +73,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English fbebdf98"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_db2f0b6e"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/Submodel/submodelElements> [

--- a/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_06.ttl
@@ -51,6 +51,15 @@
     ] ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -64,15 +73,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English fbebdf98"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_db2f0b6e"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/Submodel/submodelElements> [

--- a/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_07.ttl
@@ -51,6 +51,15 @@
     ] ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -64,15 +73,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English fbebdf98"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_db2f0b6e"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/Submodel/submodelElements> [

--- a/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_08.ttl
@@ -51,6 +51,15 @@
     ] ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -64,15 +73,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English fbebdf98"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_db2f0b6e"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/Submodel/submodelElements> [

--- a/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_09.ttl
@@ -51,6 +51,15 @@
     ] ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -64,15 +73,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English fbebdf98"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_db2f0b6e"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/Submodel/submodelElements> [

--- a/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/Submodel/idShortOverPatternExamples/fuzzed_10.ttl
@@ -51,6 +51,15 @@
     ] ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -64,15 +73,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English fbebdf98"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_db2f0b6e"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/Submodel/submodelElements> [

--- a/schemas/rdf/examples/generated/Submodel/maximal.ttl
+++ b/schemas/rdf/examples/generated/Submodel/maximal.ttl
@@ -51,6 +51,15 @@
     ] ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -64,15 +73,6 @@
                 <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English fbebdf98"^^xs:string ;
             ] ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_db2f0b6e"^^xs:string ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company07:80412e8f"^^xs:string ;
-            ] ;
         ] ;
     ] ;
     <https://admin-shell.io/aas/3/1/Submodel/submodelElements> [

--- a/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementCollection/value> [

--- a/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementCollection/value> [

--- a/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementCollection/value> [

--- a/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementCollection/value> [

--- a/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementCollection/value> [

--- a/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementCollection/value> [

--- a/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementCollection/value> [

--- a/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementCollection/value> [

--- a/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementCollection/value> [

--- a/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementCollection/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementCollection/value> [

--- a/schemas/rdf/examples/generated/SubmodelElementCollection/maximal.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementCollection/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementCollection/value> [

--- a/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_01.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_01.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementList/orderRelevant> "true"^^xs:boolean ;

--- a/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_02.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_02.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementList/orderRelevant> "true"^^xs:boolean ;

--- a/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_03.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_03.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementList/orderRelevant> "true"^^xs:boolean ;

--- a/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_04.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_04.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementList/orderRelevant> "true"^^xs:boolean ;

--- a/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_05.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_05.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementList/orderRelevant> "true"^^xs:boolean ;

--- a/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_06.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_06.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementList/orderRelevant> "true"^^xs:boolean ;

--- a/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_07.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_07.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementList/orderRelevant> "true"^^xs:boolean ;

--- a/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_08.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_08.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementList/orderRelevant> "true"^^xs:boolean ;

--- a/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_09.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_09.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementList/orderRelevant> "true"^^xs:boolean ;

--- a/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_10.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementList/idShortOverPatternExamples/fuzzed_10.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementList/orderRelevant> "true"^^xs:boolean ;

--- a/schemas/rdf/examples/generated/SubmodelElementList/maximal.ttl
+++ b/schemas/rdf/examples/generated/SubmodelElementList/maximal.ttl
@@ -49,6 +49,15 @@
         ] ;
         <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
             rdf:type aas:EmbeddedDataSpecification ;
+            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+                rdf:type aas:Reference ;
+                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
+                <https://admin-shell.io/aas/3/1/Reference/keys> [
+                    rdf:type aas:Key ;
+                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
+                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
+                ] ;
+            ] ;
             <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
                 rdf:type aas:DataSpecificationIec61360 ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -62,15 +71,6 @@
                     <https://admin-shell.io/aas/3/1/AbstractLangString/text> "Something random in English c8512bdf"^^xs:string ;
                 ] ;
                 <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/value> "something_4e9c19b7"^^xs:string ;
-            ] ;
-            <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-                rdf:type aas:Reference ;
-                <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ModelReference> ;
-                <https://admin-shell.io/aas/3/1/Reference/keys> [
-                    rdf:type aas:Key ;
-                    <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/Submodel> ;
-                    <https://admin-shell.io/aas/3/1/Key/value> "urn:another-company15:2bd0986b"^^xs:string ;
-                ] ;
             ] ;
         ] ;
         <https://admin-shell.io/aas/3/1/SubmodelElementList/orderRelevant> "true"^^xs:boolean ;

--- a/schemas/rdf/examples/generated/ValueList/maximal.ttl
+++ b/schemas/rdf/examples/generated/ValueList/maximal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                     rdf:type aas:ValueReferencePair ;
                     <https://admin-shell.io/aas/3/1/ValueReferencePair/value> "something_59dafa79"^^xs:string ;
                 ] ;
-            ] ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/ValueList/minimal.ttl
+++ b/schemas/rdf/examples/generated/ValueList/minimal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                     rdf:type aas:ValueReferencePair ;
                     <https://admin-shell.io/aas/3/1/ValueReferencePair/value> "something_59dafa79"^^xs:string ;
                 ] ;
-            ] ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/ValueReferencePair/maximal.ttl
+++ b/schemas/rdf/examples/generated/ValueReferencePair/maximal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -35,15 +44,6 @@
                         ] ;
                     ] ;
                 ] ;
-            ] ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/examples/generated/ValueReferencePair/minimal.ttl
+++ b/schemas/rdf/examples/generated/ValueReferencePair/minimal.ttl
@@ -8,6 +8,15 @@
     <https://admin-shell.io/aas/3/1/Identifiable/id> "something_142922d6"^^xs:string ;
     <https://admin-shell.io/aas/3/1/HasDataSpecification/embeddedDataSpecifications> [
         rdf:type aas:EmbeddedDataSpecification ;
+        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
+            rdf:type aas:Reference ;
+            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
+            <https://admin-shell.io/aas/3/1/Reference/keys> [
+                rdf:type aas:Key ;
+                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
+                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
+            ] ;
+        ] ;
         <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> [
             rdf:type aas:DataSpecificationIec61360 ;
             <https://admin-shell.io/aas/3/1/DataSpecificationIec61360/preferredName> [
@@ -26,15 +35,6 @@
                     rdf:type aas:ValueReferencePair ;
                     <https://admin-shell.io/aas/3/1/ValueReferencePair/value> "something_63781b6f"^^xs:string ;
                 ] ;
-            ] ;
-        ] ;
-        <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> [
-            rdf:type aas:Reference ;
-            <https://admin-shell.io/aas/3/1/Reference/type> <https://admin-shell.io/aas/3/1/ReferenceTypes/ExternalReference> ;
-            <https://admin-shell.io/aas/3/1/Reference/keys> [
-                rdf:type aas:Key ;
-                <https://admin-shell.io/aas/3/1/Key/type> <https://admin-shell.io/aas/3/1/KeyTypes/GlobalReference> ;
-                <https://admin-shell.io/aas/3/1/Key/value> "urn:some-company06:e9f47be2"^^xs:string ;
             ] ;
         ] ;
     ] ;

--- a/schemas/rdf/shacl-schema.ttl
+++ b/schemas/rdf/shacl-schema.ttl
@@ -415,15 +415,15 @@ aas:EmbeddedDataSpecificationShape a sh:NodeShape ;
     sh:targetClass aas:EmbeddedDataSpecification ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> ;
-        sh:class aas:DataSpecificationContent ;
+        sh:path <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> ;
+        sh:class aas:Reference ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecification> ;
-        sh:class aas:Reference ;
+        sh:path <https://admin-shell.io/aas/3/1/EmbeddedDataSpecification/dataSpecificationContent> ;
+        sh:class aas:DataSpecificationContent ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;

--- a/schemas/xml/AAS.xsd
+++ b/schemas/xml/AAS.xsd
@@ -277,6 +277,7 @@
   </xs:group>
   <xs:group name="embeddedDataSpecification">
     <xs:sequence>
+      <xs:element name="dataSpecification" type="reference_t"/>
       <xs:element name="dataSpecificationContent">
         <xs:complexType>
           <xs:sequence>
@@ -284,7 +285,6 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="dataSpecification" type="reference_t"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="entity">

--- a/schemas/xml/examples/generated/administrativeInformation/maximal.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/maximal.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>

--- a/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/four_digits.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/four_digits.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>

--- a/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/fuzzed_01.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>

--- a/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/fuzzed_02.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>

--- a/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/fuzzed_03.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>

--- a/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/fuzzed_04.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>

--- a/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/one.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/one.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>

--- a/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/three_digits.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/three_digits.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>

--- a/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/two_digits.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/two_digits.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>

--- a/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/zero.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/revisionOverPatternExamples/zero.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>

--- a/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/four_digits.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/four_digits.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1230</version>

--- a/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/fuzzed_01.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>59</version>

--- a/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/fuzzed_02.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>116</version>

--- a/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/fuzzed_03.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>7</version>

--- a/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/fuzzed_04.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>32</version>

--- a/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/one.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/one.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>1</version>

--- a/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/three_digits.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/three_digits.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>120</version>

--- a/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/two_digits.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/two_digits.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>10</version>

--- a/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/zero.xml
+++ b/schemas/xml/examples/generated/administrativeInformation/versionOverPatternExamples/zero.xml
@@ -4,6 +4,15 @@
 			<administration>
 				<embeddedDataSpecifications>
 					<embeddedDataSpecification>
+						<dataSpecification>
+							<type>ExternalReference</type>
+							<keys>
+								<key>
+									<type>GlobalReference</type>
+									<value>urn:something14:18179b7a</value>
+								</key>
+							</keys>
+						</dataSpecification>
 						<dataSpecificationContent>
 							<dataSpecificationIec61360>
 								<preferredName>
@@ -19,15 +28,6 @@
 								<value>something_bebf64f0</value>
 							</dataSpecificationIec61360>
 						</dataSpecificationContent>
-						<dataSpecification>
-							<type>ExternalReference</type>
-							<keys>
-								<key>
-									<type>GlobalReference</type>
-									<value>urn:something14:18179b7a</value>
-								</key>
-							</keys>
-						</dataSpecification>
 					</embeddedDataSpecification>
 				</embeddedDataSpecifications>
 				<version>0</version>

--- a/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/annotatedRelationshipElement/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/annotatedRelationshipElement/maximal.xml
+++ b/schemas/xml/examples/generated/annotatedRelationshipElement/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_01.xml
@@ -24,6 +24,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<derivedFrom>

--- a/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_02.xml
@@ -24,6 +24,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<derivedFrom>

--- a/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_03.xml
@@ -24,6 +24,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<derivedFrom>

--- a/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_04.xml
@@ -24,6 +24,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<derivedFrom>

--- a/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_05.xml
@@ -24,6 +24,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<derivedFrom>

--- a/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_06.xml
@@ -24,6 +24,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<derivedFrom>

--- a/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_07.xml
@@ -24,6 +24,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<derivedFrom>

--- a/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_08.xml
@@ -24,6 +24,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<derivedFrom>

--- a/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_09.xml
@@ -24,6 +24,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<derivedFrom>

--- a/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/assetAdministrationShell/idShortOverPatternExamples/fuzzed_10.xml
@@ -24,6 +24,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<derivedFrom>

--- a/schemas/xml/examples/generated/assetAdministrationShell/maximal.xml
+++ b/schemas/xml/examples/generated/assetAdministrationShell/maximal.xml
@@ -24,6 +24,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<derivedFrom>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/basicEventElement/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/midnight_with_24_hours.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/midnight_with_zeros.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/minus_zero_offset.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/minus_zero_offset.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/plus_zero_offset.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/plus_zero_offset.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/random_positive.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/random_positive.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/very_large_year.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/very_large_year.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/very_long_fractional_second.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/year_1_bce_is_a_leap_year.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/year_1_bce_is_a_leap_year.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/year_5_bce_is_a_leap_year.xml
+++ b/schemas/xml/examples/generated/basicEventElement/lastUpdateOverPatternExamples/year_5_bce_is_a_leap_year.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/day_seconds.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/day_seconds.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/full.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/full.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/long_second_fractal.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/long_second_fractal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/many_many_seconds.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/many_many_seconds.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/month_seconds.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/month_seconds.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/only_seconds.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/only_seconds.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/only_year.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maxIntervalOverPatternExamples/only_year.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/maximal.xml
+++ b/schemas/xml/examples/generated/basicEventElement/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/day_seconds.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/day_seconds.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/full.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/full.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/long_second_fractal.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/long_second_fractal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/many_many_seconds.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/many_many_seconds.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/month_seconds.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/month_seconds.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/only_seconds.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/only_seconds.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/only_year.xml
+++ b/schemas/xml/examples/generated/basicEventElement/minIntervalOverPatternExamples/only_year.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<observed>

--- a/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/dash.xml
+++ b/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/dash.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/dots.xml
+++ b/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/dots.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/number prefix and suffix.xml
+++ b/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/number prefix and suffix.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/only_letters.xml
+++ b/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/only_letters.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/plus.xml
+++ b/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/plus.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/random_common_MIME_type.xml
+++ b/schemas/xml/examples/generated/blob/contentTypeOverPatternExamples/random_common_MIME_type.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/blob/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/blob/maximal.xml
+++ b/schemas/xml/examples/generated/blob/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>FYFZv/O3Z+zHt1M=</value>

--- a/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 				</capability>

--- a/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 				</capability>

--- a/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 				</capability>

--- a/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 				</capability>

--- a/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 				</capability>

--- a/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 				</capability>

--- a/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 				</capability>

--- a/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 				</capability>

--- a/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 				</capability>

--- a/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/capability/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 				</capability>

--- a/schemas/xml/examples/generated/capability/maximal.xml
+++ b/schemas/xml/examples/generated/capability/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 				</capability>

--- a/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_01.xml
@@ -24,6 +24,15 @@
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ModelReference</type>
+						<keys>
+							<key>
+								<type>Submodel</type>
+								<value>urn:example14:c4971d26</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_a864dcb4</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ModelReference</type>
-						<keys>
-							<key>
-								<type>Submodel</type>
-								<value>urn:example14:c4971d26</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<isCaseOf>

--- a/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_02.xml
@@ -24,6 +24,15 @@
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ModelReference</type>
+						<keys>
+							<key>
+								<type>Submodel</type>
+								<value>urn:example14:c4971d26</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_a864dcb4</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ModelReference</type>
-						<keys>
-							<key>
-								<type>Submodel</type>
-								<value>urn:example14:c4971d26</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<isCaseOf>

--- a/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_03.xml
@@ -24,6 +24,15 @@
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ModelReference</type>
+						<keys>
+							<key>
+								<type>Submodel</type>
+								<value>urn:example14:c4971d26</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_a864dcb4</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ModelReference</type>
-						<keys>
-							<key>
-								<type>Submodel</type>
-								<value>urn:example14:c4971d26</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<isCaseOf>

--- a/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_04.xml
@@ -24,6 +24,15 @@
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ModelReference</type>
+						<keys>
+							<key>
+								<type>Submodel</type>
+								<value>urn:example14:c4971d26</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_a864dcb4</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ModelReference</type>
-						<keys>
-							<key>
-								<type>Submodel</type>
-								<value>urn:example14:c4971d26</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<isCaseOf>

--- a/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_05.xml
@@ -24,6 +24,15 @@
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ModelReference</type>
+						<keys>
+							<key>
+								<type>Submodel</type>
+								<value>urn:example14:c4971d26</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_a864dcb4</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ModelReference</type>
-						<keys>
-							<key>
-								<type>Submodel</type>
-								<value>urn:example14:c4971d26</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<isCaseOf>

--- a/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_06.xml
@@ -24,6 +24,15 @@
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ModelReference</type>
+						<keys>
+							<key>
+								<type>Submodel</type>
+								<value>urn:example14:c4971d26</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_a864dcb4</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ModelReference</type>
-						<keys>
-							<key>
-								<type>Submodel</type>
-								<value>urn:example14:c4971d26</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<isCaseOf>

--- a/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_07.xml
@@ -24,6 +24,15 @@
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ModelReference</type>
+						<keys>
+							<key>
+								<type>Submodel</type>
+								<value>urn:example14:c4971d26</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_a864dcb4</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ModelReference</type>
-						<keys>
-							<key>
-								<type>Submodel</type>
-								<value>urn:example14:c4971d26</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<isCaseOf>

--- a/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_08.xml
@@ -24,6 +24,15 @@
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ModelReference</type>
+						<keys>
+							<key>
+								<type>Submodel</type>
+								<value>urn:example14:c4971d26</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_a864dcb4</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ModelReference</type>
-						<keys>
-							<key>
-								<type>Submodel</type>
-								<value>urn:example14:c4971d26</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<isCaseOf>

--- a/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_09.xml
@@ -24,6 +24,15 @@
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ModelReference</type>
+						<keys>
+							<key>
+								<type>Submodel</type>
+								<value>urn:example14:c4971d26</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_a864dcb4</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ModelReference</type>
-						<keys>
-							<key>
-								<type>Submodel</type>
-								<value>urn:example14:c4971d26</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<isCaseOf>

--- a/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/conceptDescription/idShortOverPatternExamples/fuzzed_10.xml
@@ -24,6 +24,15 @@
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ModelReference</type>
+						<keys>
+							<key>
+								<type>Submodel</type>
+								<value>urn:example14:c4971d26</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_a864dcb4</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ModelReference</type>
-						<keys>
-							<key>
-								<type>Submodel</type>
-								<value>urn:example14:c4971d26</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<isCaseOf>

--- a/schemas/xml/examples/generated/conceptDescription/maximal.xml
+++ b/schemas/xml/examples/generated/conceptDescription/maximal.xml
@@ -24,6 +24,15 @@
 			<id>something_8ccad77f</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ModelReference</type>
+						<keys>
+							<key>
+								<type>Submodel</type>
+								<value>urn:example14:c4971d26</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -39,15 +48,6 @@
 							<value>something_a864dcb4</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ModelReference</type>
-						<keys>
-							<key>
-								<type>Submodel</type>
-								<value>urn:example14:c4971d26</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<isCaseOf>

--- a/schemas/xml/examples/generated/dataSpecificationIec61360/maximal.xml
+++ b/schemas/xml/examples/generated/dataSpecificationIec61360/maximal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -51,15 +60,6 @@
 							</levelType>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/dataSpecificationIec61360/minimal.xml
+++ b/schemas/xml/examples/generated/dataSpecificationIec61360/minimal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/embeddedDataSpecification/maximal.xml
+++ b/schemas/xml/examples/generated/embeddedDataSpecification/maximal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/embeddedDataSpecification/minimal.xml
+++ b/schemas/xml/examples/generated/embeddedDataSpecification/minimal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<statements>

--- a/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<statements>

--- a/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<statements>

--- a/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<statements>

--- a/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<statements>

--- a/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<statements>

--- a/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<statements>

--- a/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<statements>

--- a/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<statements>

--- a/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/entity/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<statements>

--- a/schemas/xml/examples/generated/entity/maximal.xml
+++ b/schemas/xml/examples/generated/entity/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<statements>

--- a/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/dash.xml
+++ b/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/dash.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/dots.xml
+++ b/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/dots.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/number prefix and suffix.xml
+++ b/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/number prefix and suffix.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/only_letters.xml
+++ b/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/only_letters.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/plus.xml
+++ b/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/plus.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/random_common_MIME_type.xml
+++ b/schemas/xml/examples/generated/file/contentTypeOverPatternExamples/random_common_MIME_type.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/file/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/maximal.xml
+++ b/schemas/xml/examples/generated/file/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>#%4b%6AT</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>RqjJsrvAJ1Uk:%9d'%8C_%81k,%Fcd?yw,@B,M=.EE%8E</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>#/%38%21&amp;</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>//QQ%BF(,xe;A.@%94($,=%38@</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>/;=:&amp;%30%1a;77@%321%A4%21;%FC:=/;=,=%13y:%2D;+J%c6%bcU%D3;j1G:sg=%EcA%f3/@z%29%B7&amp;B;=#@H%8D=U%FE%5e%22%Db?,+</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>#;</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>#%6A%6AT</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>//bVfwa.f./%DC%60O@=;;%63;6%9b;l%E8Ib@$e::9%c0;w%0F;P%bD!v,$;@$;,=$%454-:R%2C%5E%4b2B=%eB%Da%0E%C4p%5c&amp;;%de@%82%fB;v%bbw5q=%57%EE%1c;%e0%2A%af%1c0%eDm%5c%D2&amp;;k*%12%5B;%A0&amp;,:&amp;$;:&amp;%33;+,;%6c5;l%1D%35+%4a&amp;%Fe+lk,+;C,~W=+=%3bn;;-p%3f%66R+%53;o%Bd$BIW%0d%Be%0E+l=I(k%Ac:,R%e6%9E%21%7f%54;;N%F3X@%8f%03%AE(=%9b:/;%F20;0L%27%4F;;%b0:9;%D5%31%1C;21u@%CE%fAE@$=#T%7D</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>q2t2uv://777646689268.160810318.01435447069935.47:/%Be/%04@%Cd@P%dc:C$&amp;~x=;%3f9+;;sr-i=p,///;%D5@@x&amp;;V@I%16/+;%e4,@%AA@Ih:%8Dg=%F8P,v%dE%3E%03%62%FB=$R,&amp;%ac%71;u%11l8*;,;$%Faj:;;;%ee$%8b%EC@%4Alo;t,%0b%eB%D5%EA:%De;$$1:@/%8e%0D&amp;9%C8M;@5%28%4E%BC@%34;;@%EC=tL)x(/M%D3%aF&amp;%Ec;=%aa$$j;;%B3@hk=e:%DB%24Z;%F6%9E+%8e;=;%ba;;%b3;;p%f11=%34%c0;#lR:+k%BE4%EB</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>#%59T=%e1&amp;&amp;%b4%53EYU?,/q%87%c6He</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/made_up_01.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/made_up_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>http://www.example.org</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/made_up_02.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/made_up_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>ftp://ftp.is.co.za/rfc/rfc1808.txt</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/made_up_03.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/made_up_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>mailto:John.Doe@example.org</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/made_up_04.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/made_up_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>news:comp.infosystems.www.servers.unix</value>

--- a/schemas/xml/examples/generated/file/valueOverPatternExamples/made_up_05.xml
+++ b/schemas/xml/examples/generated/file/valueOverPatternExamples/made_up_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>telnet://192.0.2.16:80/</value>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_1.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_2.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_3.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_variant_1.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_variant_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_variant_2.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_region_variant_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_1.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_2.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_variant.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_script_region_variant.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_1.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_2.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_3.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/language_variant_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_subtags_1.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_subtags_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_subtags_2.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/private_use_subtags_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_1.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_2.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_3.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/languageOverPatternExamples/tag_with_extension_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/maximal.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/maximal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/minimal.xml
+++ b/schemas/xml/examples/generated/langStringDefinitionTypeIec61360/minimal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_1.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_2.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_3.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_variant_1.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_variant_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_variant_2.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_region_variant_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_1.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_2.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_variant.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_script_region_variant.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_1.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_2.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_3.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/language_variant_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_subtags_1.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_subtags_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_subtags_2.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/private_use_subtags_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_1.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_2.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_3.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/languageOverPatternExamples/tag_with_extension_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/maximal.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/maximal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/minimal.xml
+++ b/schemas/xml/examples/generated/langStringPreferredNameTypeIec61360/minimal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -19,15 +28,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/extended_language_subtags_4.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_region_1.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_region_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_region_2.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_region_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_region_3.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_region_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_region_variant_1.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_region_variant_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_region_variant_2.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_region_variant_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_1.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_2.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_variant.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_script_region_variant.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_subtag_plus_script_subtag_4.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_1.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_2.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_3.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/language_variant_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_4.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_registry_values_5.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_subtags_1.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_subtags_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_subtags_2.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/private_use_subtags_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/simple_language_subtag_example_of_a_grandfathered_tag.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_1.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_1.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_2.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_2.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_3.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/languageOverPatternExamples/tag_with_extension_3.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/maximal.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/maximal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/langStringShortNameTypeIec61360/minimal.xml
+++ b/schemas/xml/examples/generated/langStringShortNameTypeIec61360/minimal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							<value>something_13759f45</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/levelType/maximal.xml
+++ b/schemas/xml/examples/generated/levelType/maximal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							</levelType>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/levelType/minimal.xml
+++ b/schemas/xml/examples/generated/levelType/minimal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							</levelType>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/multiLanguageProperty/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/multiLanguageProperty/maximal.xml
+++ b/schemas/xml/examples/generated/multiLanguageProperty/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<inputVariables>

--- a/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<inputVariables>

--- a/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<inputVariables>

--- a/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<inputVariables>

--- a/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<inputVariables>

--- a/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<inputVariables>

--- a/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<inputVariables>

--- a/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<inputVariables>

--- a/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<inputVariables>

--- a/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/operation/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<inputVariables>

--- a/schemas/xml/examples/generated/operation/maximal.xml
+++ b/schemas/xml/examples/generated/operation/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<inputVariables>

--- a/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/property/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/property/maximal.xml
+++ b/schemas/xml/examples/generated/property/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/range/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/range/maximal.xml
+++ b/schemas/xml/examples/generated/range/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<valueType>xs:decimal</valueType>

--- a/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/referenceElement/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/referenceElement/maximal.xml
+++ b/schemas/xml/examples/generated/referenceElement/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/relationshipElement/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/relationshipElement/maximal.xml
+++ b/schemas/xml/examples/generated/relationshipElement/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<first>

--- a/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 			</qualifiers>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company07:80412e8f</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -66,15 +75,6 @@
 							<value>something_db2f0b6e</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company07:80412e8f</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<submodelElements>

--- a/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 			</qualifiers>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company07:80412e8f</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -66,15 +75,6 @@
 							<value>something_db2f0b6e</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company07:80412e8f</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<submodelElements>

--- a/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 			</qualifiers>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company07:80412e8f</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -66,15 +75,6 @@
 							<value>something_db2f0b6e</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company07:80412e8f</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<submodelElements>

--- a/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 			</qualifiers>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company07:80412e8f</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -66,15 +75,6 @@
 							<value>something_db2f0b6e</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company07:80412e8f</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<submodelElements>

--- a/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 			</qualifiers>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company07:80412e8f</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -66,15 +75,6 @@
 							<value>something_db2f0b6e</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company07:80412e8f</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<submodelElements>

--- a/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 			</qualifiers>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company07:80412e8f</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -66,15 +75,6 @@
 							<value>something_db2f0b6e</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company07:80412e8f</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<submodelElements>

--- a/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 			</qualifiers>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company07:80412e8f</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -66,15 +75,6 @@
 							<value>something_db2f0b6e</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company07:80412e8f</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<submodelElements>

--- a/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 			</qualifiers>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company07:80412e8f</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -66,15 +75,6 @@
 							<value>something_db2f0b6e</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company07:80412e8f</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<submodelElements>

--- a/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 			</qualifiers>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company07:80412e8f</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -66,15 +75,6 @@
 							<value>something_db2f0b6e</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company07:80412e8f</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<submodelElements>

--- a/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/submodel/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 			</qualifiers>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company07:80412e8f</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -66,15 +75,6 @@
 							<value>something_db2f0b6e</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company07:80412e8f</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<submodelElements>

--- a/schemas/xml/examples/generated/submodel/maximal.xml
+++ b/schemas/xml/examples/generated/submodel/maximal.xml
@@ -51,6 +51,15 @@
 			</qualifiers>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company07:80412e8f</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -66,15 +75,6 @@
 							<value>something_db2f0b6e</value>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company07:80412e8f</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<submodelElements>

--- a/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/submodelElementCollection/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/submodelElementCollection/maximal.xml
+++ b/schemas/xml/examples/generated/submodelElementCollection/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<value>

--- a/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_01.xml
+++ b/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_01.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>

--- a/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_02.xml
+++ b/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_02.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>

--- a/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_03.xml
+++ b/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_03.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>

--- a/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_04.xml
+++ b/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_04.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>

--- a/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_05.xml
+++ b/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_05.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>

--- a/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_06.xml
+++ b/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_06.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>

--- a/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_07.xml
+++ b/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_07.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>

--- a/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_08.xml
+++ b/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_08.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>

--- a/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_09.xml
+++ b/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_09.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>

--- a/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_10.xml
+++ b/schemas/xml/examples/generated/submodelElementList/idShortOverPatternExamples/fuzzed_10.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>

--- a/schemas/xml/examples/generated/submodelElementList/maximal.xml
+++ b/schemas/xml/examples/generated/submodelElementList/maximal.xml
@@ -51,6 +51,15 @@
 					</qualifiers>
 					<embeddedDataSpecifications>
 						<embeddedDataSpecification>
+							<dataSpecification>
+								<type>ModelReference</type>
+								<keys>
+									<key>
+										<type>Submodel</type>
+										<value>urn:another-company15:2bd0986b</value>
+									</key>
+								</keys>
+							</dataSpecification>
 							<dataSpecificationContent>
 								<dataSpecificationIec61360>
 									<preferredName>
@@ -66,15 +75,6 @@
 									<value>something_4e9c19b7</value>
 								</dataSpecificationIec61360>
 							</dataSpecificationContent>
-							<dataSpecification>
-								<type>ModelReference</type>
-								<keys>
-									<key>
-										<type>Submodel</type>
-										<value>urn:another-company15:2bd0986b</value>
-									</key>
-								</keys>
-							</dataSpecification>
 						</embeddedDataSpecification>
 					</embeddedDataSpecifications>
 					<orderRelevant>true</orderRelevant>

--- a/schemas/xml/examples/generated/valueList/maximal.xml
+++ b/schemas/xml/examples/generated/valueList/maximal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							</valueList>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/valueList/minimal.xml
+++ b/schemas/xml/examples/generated/valueList/minimal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							</valueList>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/valueReferencePair/maximal.xml
+++ b/schemas/xml/examples/generated/valueReferencePair/maximal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -34,15 +43,6 @@
 							</valueList>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>

--- a/schemas/xml/examples/generated/valueReferencePair/minimal.xml
+++ b/schemas/xml/examples/generated/valueReferencePair/minimal.xml
@@ -4,6 +4,15 @@
 			<id>something_142922d6</id>
 			<embeddedDataSpecifications>
 				<embeddedDataSpecification>
+					<dataSpecification>
+						<type>ExternalReference</type>
+						<keys>
+							<key>
+								<type>GlobalReference</type>
+								<value>urn:some-company06:e9f47be2</value>
+							</key>
+						</keys>
+					</dataSpecification>
 					<dataSpecificationContent>
 						<dataSpecificationIec61360>
 							<preferredName>
@@ -25,15 +34,6 @@
 							</valueList>
 						</dataSpecificationIec61360>
 					</dataSpecificationContent>
-					<dataSpecification>
-						<type>ExternalReference</type>
-						<keys>
-							<key>
-								<type>GlobalReference</type>
-								<value>urn:some-company06:e9f47be2</value>
-							</key>
-						</keys>
-					</dataSpecification>
 				</embeddedDataSpecification>
 			</embeddedDataSpecifications>
 			<assetInformation>


### PR DESCRIPTION
Previously we mistakenly thought that attribute `dataSpecification` of class `EmbeddedDataSpecification` was optional and we did a bugfix for this in [aas-core-meta#328](https://github.com/aas-core-works/aas-core-meta/pull/328). However, we later discovered that this was a mistake in a graphic of the specification and `dataSpecification` was indeed mandatory (see discussion in [aas-core-meta#326](https://github.com/aas-core-works/aas-core-meta/issues/326)). Therefore we reverted the added `Optional` in the type hint in [aas-core-meta#329](https://github.com/aas-core-works/aas-core-meta/pull/329).

Sadly, the issue was not finished with this, as we forgot to also revert the order of the attributes that had changed due to the fact that optional attributes need to be defined behind mandatory attributes. This had been found in #477 with regards to V3.0 and had been fixed for v3.0 in [aas-core-meta#353](https://github.com/aas-core-works/aas-core-meta/pull/353). Unfortunately we forgot to adapt this change also for V3.1.

So now, another issue was filed in #585, notifying us of the changed order of attributes in V3.1.

Finally, [aas-core-meta#371](https://github.com/aas-core-works/aas-core-meta/pull/371) reverts the order of the attributes of `Embedded_data_specification` for V3.1 as well and we propagate the changes to the schema and example files here.

Fixes #585